### PR TITLE
fix: emit X-Glean-Include-Experimental header (not X-Glean-Experimental)

### DIFF
--- a/internal/hooks/x_glean_hook.go
+++ b/internal/hooks/x_glean_hook.go
@@ -5,6 +5,13 @@ import (
 	"os"
 )
 
+// Header names set by XGleanHook. Kept as consts so the header names live in
+// a single place.
+const (
+	headerExcludeDeprecatedAfter = "X-Glean-Exclude-Deprecated-After"
+	headerIncludeExperimental    = "X-Glean-Include-Experimental"
+)
+
 // XGleanHook is a beforeRequest hook that sets X-Glean headers for
 // experimental features and deprecation testing.
 type XGleanHook struct{}
@@ -33,11 +40,11 @@ func (h *XGleanHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Reque
 
 	// Set headers if values are present
 	if deprecatedAfter != "" {
-		req.Header.Set("X-Glean-Exclude-Deprecated-After", deprecatedAfter)
+		req.Header.Set(headerExcludeDeprecatedAfter, deprecatedAfter)
 	}
 
 	if experimentalValue != "" {
-		req.Header.Set("X-Glean-Include-Experimental", experimentalValue)
+		req.Header.Set(headerIncludeExperimental, experimentalValue)
 	}
 
 	return req, nil

--- a/internal/hooks/x_glean_hook.go
+++ b/internal/hooks/x_glean_hook.go
@@ -9,7 +9,7 @@ import (
 // experimental features and deprecation testing.
 type XGleanHook struct{}
 
-// BeforeRequest sets the X-Glean-Exclude-Deprecated-After and X-Glean-Experimental
+// BeforeRequest sets the X-Glean-Exclude-Deprecated-After and X-Glean-Include-Experimental
 // headers based on environment variables or SDK configuration.
 // Environment variables take precedence over SDK options.
 func (h *XGleanHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
@@ -37,7 +37,7 @@ func (h *XGleanHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Reque
 	}
 
 	if experimentalValue != "" {
-		req.Header.Set("X-Glean-Experimental", experimentalValue)
+		req.Header.Set("X-Glean-Include-Experimental", experimentalValue)
 	}
 
 	return req, nil

--- a/internal/hooks/x_glean_hook_test.go
+++ b/internal/hooks/x_glean_hook_test.go
@@ -40,11 +40,11 @@ func TestXGleanHook_NoConfiguration(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if result.Header.Get("X-Glean-Exclude-Deprecated-After") != "" {
+	if result.Header.Get(headerExcludeDeprecatedAfter) != "" {
 		t.Error("expected X-Glean-Exclude-Deprecated-After header to not be set")
 	}
 
-	if result.Header.Get("X-Glean-Include-Experimental") != "" {
+	if result.Header.Get(headerIncludeExperimental) != "" {
 		t.Error("expected X-Glean-Include-Experimental header to not be set")
 	}
 }
@@ -70,7 +70,7 @@ func TestXGleanHook_SDKOptions_ExcludeDeprecatedAfter(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2026-10-15" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2026-10-15" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2026-10-15', got '%s'", got)
 	}
 }
@@ -96,7 +96,7 @@ func TestXGleanHook_SDKOptions_IncludeExperimental(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
@@ -122,7 +122,7 @@ func TestXGleanHook_SDKOptions_IncludeExperimentalFalse(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if result.Header.Get("X-Glean-Include-Experimental") != "" {
+	if result.Header.Get(headerIncludeExperimental) != "" {
 		t.Error("expected X-Glean-Include-Experimental header to not be set when IncludeExperimental is false")
 	}
 }
@@ -149,11 +149,11 @@ func TestXGleanHook_SDKOptions_BothOptions(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2026-10-15" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2026-10-15" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2026-10-15', got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
@@ -174,7 +174,7 @@ func TestXGleanHook_EnvVars_ExcludeDeprecatedAfter(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2027-01-01" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2027-01-01" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2027-01-01', got '%s'", got)
 	}
 }
@@ -195,7 +195,7 @@ func TestXGleanHook_EnvVars_IncludeExperimental(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
@@ -217,11 +217,11 @@ func TestXGleanHook_EnvVars_BothOptions(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2027-06-15" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2027-06-15" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2027-06-15', got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
@@ -249,7 +249,7 @@ func TestXGleanHook_EnvVarsPrecedence_ExcludeDeprecatedAfter(t *testing.T) {
 	}
 
 	// Environment variable should take precedence
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2027-12-31" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2027-12-31" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2027-12-31' (from env var), got '%s'", got)
 	}
 }
@@ -277,7 +277,7 @@ func TestXGleanHook_EnvVarsPrecedence_IncludeExperimental(t *testing.T) {
 	}
 
 	// Environment variable should take precedence
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true' (from env var), got '%s'", got)
 	}
 }
@@ -307,11 +307,11 @@ func TestXGleanHook_EnvVarsPrecedence_BothOptions(t *testing.T) {
 	}
 
 	// Environment variables should take precedence
-	if got := result.Header.Get("X-Glean-Exclude-Deprecated-After"); got != "2028-01-01" {
+	if got := result.Header.Get(headerExcludeDeprecatedAfter); got != "2028-01-01" {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2028-01-01' (from env var), got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+	if got := result.Header.Get(headerIncludeExperimental); got != "true" {
 		t.Errorf("expected X-Glean-Include-Experimental header to be 'true' (from env var), got '%s'", got)
 	}
 }

--- a/internal/hooks/x_glean_hook_test.go
+++ b/internal/hooks/x_glean_hook_test.go
@@ -44,8 +44,8 @@ func TestXGleanHook_NoConfiguration(t *testing.T) {
 		t.Error("expected X-Glean-Exclude-Deprecated-After header to not be set")
 	}
 
-	if result.Header.Get("X-Glean-Experimental") != "" {
-		t.Error("expected X-Glean-Experimental header to not be set")
+	if result.Header.Get("X-Glean-Include-Experimental") != "" {
+		t.Error("expected X-Glean-Include-Experimental header to not be set")
 	}
 }
 
@@ -96,8 +96,8 @@ func TestXGleanHook_SDKOptions_IncludeExperimental(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true', got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
 
@@ -122,8 +122,8 @@ func TestXGleanHook_SDKOptions_IncludeExperimentalFalse(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if result.Header.Get("X-Glean-Experimental") != "" {
-		t.Error("expected X-Glean-Experimental header to not be set when IncludeExperimental is false")
+	if result.Header.Get("X-Glean-Include-Experimental") != "" {
+		t.Error("expected X-Glean-Include-Experimental header to not be set when IncludeExperimental is false")
 	}
 }
 
@@ -153,8 +153,8 @@ func TestXGleanHook_SDKOptions_BothOptions(t *testing.T) {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2026-10-15', got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true', got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
 
@@ -195,8 +195,8 @@ func TestXGleanHook_EnvVars_IncludeExperimental(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true', got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
 
@@ -221,8 +221,8 @@ func TestXGleanHook_EnvVars_BothOptions(t *testing.T) {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2027-06-15', got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true', got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true', got '%s'", got)
 	}
 }
 
@@ -277,8 +277,8 @@ func TestXGleanHook_EnvVarsPrecedence_IncludeExperimental(t *testing.T) {
 	}
 
 	// Environment variable should take precedence
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true' (from env var), got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true' (from env var), got '%s'", got)
 	}
 }
 
@@ -311,7 +311,7 @@ func TestXGleanHook_EnvVarsPrecedence_BothOptions(t *testing.T) {
 		t.Errorf("expected X-Glean-Exclude-Deprecated-After header to be '2028-01-01' (from env var), got '%s'", got)
 	}
 
-	if got := result.Header.Get("X-Glean-Experimental"); got != "true" {
-		t.Errorf("expected X-Glean-Experimental header to be 'true' (from env var), got '%s'", got)
+	if got := result.Header.Get("X-Glean-Include-Experimental"); got != "true" {
+		t.Errorf("expected X-Glean-Include-Experimental header to be 'true' (from env var), got '%s'", got)
 	}
 }


### PR DESCRIPTION
## Summary

The `XGleanHook` `BeforeRequest` hook correctly reads the `IncludeExperimental` SDK option and the `X_GLEAN_INCLUDE_EXPERIMENTAL` env var, but sets the **wrong header name**. It emits `X-Glean-Experimental` when the backend expects **`X-Glean-Include-Experimental`**.

This corrects the header name in the hook and its tests. Behavior (opt-in, env var precedence) is unchanged.

## Changes
- `internal/hooks/x_glean_hook.go` — header name (and doc comment)
- `internal/hooks/x_glean_hook_test.go` — updated assertions

## Verification
- `go test ./internal/hooks/` → ok

## Related
Same bug exists in the TypeScript, Python, and Java SDKs; companion PRs fix each. Env var name was already correct and is unchanged.
