### PR TITLE
Update CODEOWNERS to team PACT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gleanwork/api-client-reviewers
+* @gleanwork/PACT


### PR DESCRIPTION
Updates the CODEOWNERS file to assign ownership to `@gleanwork/PACT`.